### PR TITLE
Fix exceptions on mono.

### DIFF
--- a/src/Torshify.Shell/Program.cs
+++ b/src/Torshify.Shell/Program.cs
@@ -132,6 +132,12 @@ namespace Torshify.Shell
             ConsoleEx.Write("Query >> ", ConsoleColor.Green);
             string query = Console.ReadLine();
 
+            if (string.IsNullOrEmpty(query))
+            {
+                ConsoleEx.WriteLine("Query string for search can't be empty", ConsoleColor.Red);
+                return;
+            }
+
             ConsoleEx.WriteLine("Searching..", ConsoleColor.Yellow);
             ISearch search = Session
                 .Search(query, 0, 25, 0, 25, 0, 25, 0, 25, SearchType.Standard)

--- a/src/Torshify/Core/Native/NativeAlbum.cs
+++ b/src/Torshify/Core/Native/NativeAlbum.cs
@@ -153,7 +153,6 @@ namespace Torshify.Core.Native
                 finally
                 {
                     AlbumManager.Remove(Handle);
-                    Handle = IntPtr.Zero;
                 }
 
                 Debug.WriteLine("Album disposed");

--- a/src/Torshify/Core/Native/NativeAlbumBrowse.cs
+++ b/src/Torshify/Core/Native/NativeAlbumBrowse.cs
@@ -182,10 +182,6 @@ namespace Torshify.Core.Native
                 catch
                 {
                 }
-                finally
-                {
-                    Handle = IntPtr.Zero;
-                }
             }
 
             base.Dispose(disposing);

--- a/src/Torshify/Core/Native/NativeAlbumBrowse.cs
+++ b/src/Torshify/Core/Native/NativeAlbumBrowse.cs
@@ -176,7 +176,7 @@ namespace Torshify.Core.Native
                 {
                     lock (Spotify.Mutex)
                     {
-                        Spotify.sp_albumbrowse_release(Handle);
+                        Ensure(() => Spotify.sp_albumbrowse_release(Handle));
                     }
                 }
                 catch

--- a/src/Torshify/Core/Native/NativeAlbumBrowse.cs
+++ b/src/Torshify/Core/Native/NativeAlbumBrowse.cs
@@ -177,11 +177,14 @@ namespace Torshify.Core.Native
                     lock (Spotify.Mutex)
                     {
                         Spotify.sp_albumbrowse_release(Handle);
-                        Handle = IntPtr.Zero;
                     }
                 }
                 catch
                 {
+                }
+                finally
+                {
+                    Handle = IntPtr.Zero;
                 }
             }
 

--- a/src/Torshify/Core/Native/NativeArtist.cs
+++ b/src/Torshify/Core/Native/NativeArtist.cs
@@ -95,7 +95,6 @@ namespace Torshify.Core.Native
                 finally
                 {
                     ArtistManager.Remove(Handle);
-                    Handle = IntPtr.Zero;
                 }
             }
 

--- a/src/Torshify/Core/Native/NativeArtist.cs
+++ b/src/Torshify/Core/Native/NativeArtist.cs
@@ -86,7 +86,7 @@ namespace Torshify.Core.Native
                 {
                     lock (Spotify.Mutex)
                     {
-                        Spotify.sp_artist_release(Handle);
+                        Ensure(() => Spotify.sp_artist_release(Handle));
                     }
                 }
                 catch

--- a/src/Torshify/Core/Native/NativeArtistBrowse.cs
+++ b/src/Torshify/Core/Native/NativeArtistBrowse.cs
@@ -210,10 +210,6 @@ namespace Torshify.Core.Native
                 catch
                 {
                 }
-                finally
-                {
-                    Handle = IntPtr.Zero;
-                }
             }
 
             base.Dispose(disposing);

--- a/src/Torshify/Core/Native/NativeArtistBrowse.cs
+++ b/src/Torshify/Core/Native/NativeArtistBrowse.cs
@@ -202,7 +202,7 @@ namespace Torshify.Core.Native
                 {
                     lock (Spotify.Mutex)
                     {
-                        Spotify.sp_artistbrowse_release(Handle);
+                        Ensure(() => Spotify.sp_artistbrowse_release(Handle));
                     }
 
                     GC.KeepAlive(_browseCompleteCallback);

--- a/src/Torshify/Core/Native/NativeArtistBrowse.cs
+++ b/src/Torshify/Core/Native/NativeArtistBrowse.cs
@@ -203,13 +203,16 @@ namespace Torshify.Core.Native
                     lock (Spotify.Mutex)
                     {
                         Spotify.sp_artistbrowse_release(Handle);
-                        Handle = IntPtr.Zero;
                     }
 
                     GC.KeepAlive(_browseCompleteCallback);
                 }
                 catch
                 {
+                }
+                finally
+                {
+                    Handle = IntPtr.Zero;
                 }
             }
 

--- a/src/Torshify/Core/Native/NativeImage.cs
+++ b/src/Torshify/Core/Native/NativeImage.cs
@@ -177,8 +177,10 @@ namespace Torshify.Core.Native
                 {
                     lock (Spotify.Mutex)
                     {
-                        Spotify.sp_image_remove_load_callback(Handle, _imageLoaded, IntPtr.Zero);
-                        Spotify.sp_image_release(Handle);
+                        Ensure(() => {
+                            Spotify.sp_image_remove_load_callback(Handle, _imageLoaded, IntPtr.Zero);
+                            Spotify.sp_image_release(Handle);
+                        });
                     }
                 }
                 catch

--- a/src/Torshify/Core/Native/NativeImage.cs
+++ b/src/Torshify/Core/Native/NativeImage.cs
@@ -184,10 +184,6 @@ namespace Torshify.Core.Native
                 catch
                 {
                 }
-                finally
-                {
-                    Handle = IntPtr.Zero;
-                }
             }
 
             base.Dispose(disposing);

--- a/src/Torshify/Core/Native/NativeLink.cs
+++ b/src/Torshify/Core/Native/NativeLink.cs
@@ -112,7 +112,6 @@ namespace Torshify.Core.Native
                 finally
                 {
                     LinkManager.Remove(Handle);
-                    Handle = IntPtr.Zero;
                 }
 
 #if DEBUG_VERBOSE

--- a/src/Torshify/Core/Native/NativeLink.cs
+++ b/src/Torshify/Core/Native/NativeLink.cs
@@ -103,7 +103,7 @@ namespace Torshify.Core.Native
                 {
                     lock (Spotify.Mutex)
                     {
-                        Spotify.sp_link_release(Handle);
+                        Ensure(() => Spotify.sp_link_release(Handle));
                     }
                 }
                 catch

--- a/src/Torshify/Core/Native/NativePlaylist.cs
+++ b/src/Torshify/Core/Native/NativePlaylist.cs
@@ -387,7 +387,7 @@ namespace Torshify.Core.Native
 
                     try
                     {
-                        Spotify.sp_playlist_release(Handle);
+                        Ensure(() => Spotify.sp_playlist_release(Handle));
                     }
                     catch
                     {

--- a/src/Torshify/Core/Native/NativePlaylist.cs
+++ b/src/Torshify/Core/Native/NativePlaylist.cs
@@ -396,7 +396,6 @@ namespace Torshify.Core.Native
                     {
                         PlaylistTrackManager.RemoveAll(this);
                         PlaylistManager.Remove(Handle);
-                        Handle = IntPtr.Zero;
                         Debug.WriteLine("Playlist disposed");
                     }
                 }

--- a/src/Torshify/Core/Native/NativePlaylistContainer.cs
+++ b/src/Torshify/Core/Native/NativePlaylistContainer.cs
@@ -146,7 +146,6 @@ namespace Torshify.Core.Native
                 finally
                 {
                     PlaylistContainerManager.Remove(Handle);
-                    Handle = IntPtr.Zero;
                     Debug.WriteLine("Playlist container disposed");
                 }
             }

--- a/src/Torshify/Core/Native/NativeSearch.cs
+++ b/src/Torshify/Core/Native/NativeSearch.cs
@@ -311,7 +311,7 @@ namespace Torshify.Core.Native
 
                     lock (Spotify.Mutex)
                     {
-                        Spotify.sp_search_release(Handle);
+                        Ensure(() => Spotify.sp_search_release(Handle));
                     }
                 }
                 catch

--- a/src/Torshify/Core/Native/NativeSearch.cs
+++ b/src/Torshify/Core/Native/NativeSearch.cs
@@ -317,10 +317,6 @@ namespace Torshify.Core.Native
                 catch
                 {
                 }
-                finally
-                {
-                    Handle = IntPtr.Zero;
-                }
             }
 
             base.Dispose(disposing);

--- a/src/Torshify/Core/Native/NativeSearch.cs
+++ b/src/Torshify/Core/Native/NativeSearch.cs
@@ -312,11 +312,14 @@ namespace Torshify.Core.Native
                     lock (Spotify.Mutex)
                     {
                         Spotify.sp_search_release(Handle);
-                        Handle = IntPtr.Zero;
                     }
                 }
                 catch
                 {
+                }
+                finally
+                {
+                    Handle = IntPtr.Zero;
                 }
             }
 

--- a/src/Torshify/Core/Native/NativeSession.cs
+++ b/src/Torshify/Core/Native/NativeSession.cs
@@ -961,7 +961,6 @@ namespace Torshify.Core.Native
                 }
                 finally
                 {
-                    Handle = IntPtr.Zero;
                     Debug.WriteLine("Session disposed");
                 }
             }

--- a/src/Torshify/Core/Native/NativeSession.cs
+++ b/src/Torshify/Core/Native/NativeSession.cs
@@ -951,7 +951,7 @@ namespace Torshify.Core.Native
                             Debug.WriteLineIf(error != Error.OK, error.GetMessage());
                         }
 
-                        error = Spotify.sp_session_release(Handle);
+                        Ensure(() => error = Spotify.sp_session_release(Handle));
                         Debug.WriteLineIf(error != Error.OK, error.GetMessage());
                     }
                 }

--- a/src/Torshify/Core/Native/NativeSession.cs
+++ b/src/Torshify/Core/Native/NativeSession.cs
@@ -953,7 +953,6 @@ namespace Torshify.Core.Native
 
                         error = Spotify.sp_session_release(Handle);
                         Debug.WriteLineIf(error != Error.OK, error.GetMessage());
-                        Handle = IntPtr.Zero;
                     }
                 }
                 catch
@@ -962,6 +961,7 @@ namespace Torshify.Core.Native
                 }
                 finally
                 {
+                    Handle = IntPtr.Zero;
                     Debug.WriteLine("Session disposed");
                 }
             }

--- a/src/Torshify/Core/Native/NativeToplistBrowse.cs
+++ b/src/Torshify/Core/Native/NativeToplistBrowse.cs
@@ -178,10 +178,6 @@ namespace Torshify.Core.Native
                 catch
                 {
                 }
-                finally
-                {
-                    Handle = IntPtr.Zero;
-                }
             }
 
             base.Dispose(disposing);

--- a/src/Torshify/Core/Native/NativeTrack.cs
+++ b/src/Torshify/Core/Native/NativeTrack.cs
@@ -289,7 +289,7 @@ namespace Torshify.Core.Native
                 {
                     lock (Spotify.Mutex)
                     {
-                        Spotify.sp_track_release(Handle);
+                        Ensure(() => Spotify.sp_track_release(Handle));
                     }
                 }
                 catch

--- a/src/Torshify/Core/Native/NativeTrack.cs
+++ b/src/Torshify/Core/Native/NativeTrack.cs
@@ -298,7 +298,6 @@ namespace Torshify.Core.Native
                 finally
                 {
                     TrackManager.Remove(Handle);
-                    Handle = IntPtr.Zero;
                     Debug.WriteLine("Track disposed");
                 }
             }

--- a/src/Torshify/Core/Native/NativeUser.cs
+++ b/src/Torshify/Core/Native/NativeUser.cs
@@ -83,7 +83,7 @@ namespace Torshify.Core.Native
                 {
                     lock (Spotify.Mutex)
                     {
-                        Spotify.sp_user_release(Handle);
+                        Ensure(() => Spotify.sp_user_release(Handle));
                     }
                 }
                 catch

--- a/src/Torshify/Core/Native/NativeUser.cs
+++ b/src/Torshify/Core/Native/NativeUser.cs
@@ -89,10 +89,6 @@ namespace Torshify.Core.Native
                 catch
                 {
                 }
-                finally
-                {
-                    Handle = IntPtr.Zero;
-                }
             }
 
             base.Dispose(disposing);

--- a/src/Torshify/Core/Native/Spotify.Error.cs
+++ b/src/Torshify/Core/Native/Spotify.Error.cs
@@ -11,6 +11,7 @@ namespace Torshify.Core.Native
       /// <param name="error">The error code.</param>
       /// <returns>The text-representation of the error.</returns>
       [DllImport("libspotify")]
+      [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(MarshalPtrToUtf8))]
       public static extern string sp_error_message(Error error);
   }
 }

--- a/src/Torshify/Core/Native/Spotify.Search.cs
+++ b/src/Torshify/Core/Native/Spotify.Search.cs
@@ -195,6 +195,7 @@ namespace Torshify.Core.Native
         /// <param name="index"></param>
         /// <returns></returns>
         [DllImport("libspotify")]
+        [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(MarshalPtrToUtf8))]
         internal static extern string sp_search_playlist_name(IntPtr searchPtr, int index);
 
         /// <summary>
@@ -204,6 +205,7 @@ namespace Torshify.Core.Native
         /// <param name="index"></param>
         /// <returns></returns>
         [DllImport("libspotify")]
+        [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(MarshalPtrToUtf8))]
         internal static extern string sp_search_playlist_uri(IntPtr searchPtr, int index);
 
         /// <summary>
@@ -213,6 +215,7 @@ namespace Torshify.Core.Native
         /// <param name="index"></param>
         /// <returns></returns>
         [DllImport("libspotify")]
+        [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(MarshalPtrToUtf8))]
         internal static extern string sp_search_playlist_image_uri(IntPtr searchPtr, int index);
     }
 }

--- a/src/Torshify/Core/Native/Spotify.Session.cs
+++ b/src/Torshify/Core/Native/Spotify.Session.cs
@@ -12,6 +12,7 @@ namespace Torshify.Core.Native
         /// </summary>
         /// <returns></returns>
         [DllImport("libspotify")]
+        [return: MarshalAs(UnmanagedType.CustomMarshaler, MarshalTypeRef = typeof(MarshalPtrToUtf8))]
         internal static extern string sp_build_id();
 
         /// <summary>

--- a/src/Torshify/Core/Native/Spotify.cs
+++ b/src/Torshify/Core/Native/Spotify.cs
@@ -16,18 +16,6 @@ namespace Torshify.Core.Native
 
         #endregion Fields
 
-        #region Constructors
-
-        static Spotify()
-        {
-            Console.ForegroundColor = ConsoleColor.Green;
-            Console.WriteLine("torshify uses SPOTIFY(R) CORE");
-            Console.ForegroundColor = ConsoleColor.Gray;
-            Console.WriteLine(sp_build_id());
-        }
-
-        #endregion Constructors
-
         #region Enumerations
 
         internal enum SpotifySampletype

--- a/src/Torshify/Core/NativeObject.cs
+++ b/src/Torshify/Core/NativeObject.cs
@@ -89,6 +89,8 @@ namespace Torshify.Core
             }
 
             // get rid of unmanaged resources
+
+            Handle = IntPtr.Zero;
         }
 
         protected void AssertHandle()

--- a/src/Torshify/Core/NativeObject.cs
+++ b/src/Torshify/Core/NativeObject.cs
@@ -101,6 +101,17 @@ namespace Torshify.Core
             }
         }
 
+        public void Ensure(Action action)
+        {
+            if ((Session is NativeObject) && !(Session as NativeObject).IsInvalid)
+            {
+                if (action != null)
+                {
+                    action();
+                }
+            }
+        }
+
         #endregion Protected Methods
     }
 }


### PR DESCRIPTION
This pull request contains 2 commits, one just removes the verbosity of loading the library, the other fixes some free exceptions on mono.

If you have an external method returning a string mono assumes automatically that it has to be freed. By specifying that we want to use the marshaller we can avoid this. 
